### PR TITLE
Add bootstrap views for collections

### DIFF
--- a/designs/templates/designs/base.html
+++ b/designs/templates/designs/base.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}BoxedIn{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  </head>
+  <body class="container py-4">
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/designs/templates/designs/collection_detail.html
+++ b/designs/templates/designs/collection_detail.html
@@ -1,0 +1,16 @@
+{% extends "designs/base.html" %}
+{% block title %}{{ collection.name }}{% endblock %}
+{% block content %}
+<h1 class="mb-4">{{ collection.name }}</h1>
+<p class="mb-4">{{ collection.description }}</p>
+<h2 class="mb-3">Designs</h2>
+<div class="list-group">
+  {% for design in designs %}
+  <a href="{% url 'design-detail' design.pk %}" class="list-group-item list-group-item-action">
+    {{ design.name }} ({{ design.dimensions.width }}x{{ design.dimensions.height }})
+  </a>
+  {% empty %}
+  <p>No designs available.</p>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/designs/templates/designs/collection_list.html
+++ b/designs/templates/designs/collection_list.html
@@ -1,0 +1,15 @@
+{% extends "designs/base.html" %}
+{% block title %}Collections{% endblock %}
+{% block content %}
+<h1 class="mb-4">Collections</h1>
+<div class="list-group">
+  {% for collection in collections %}
+  <a href="{% url 'collection-detail' collection.pk %}" class="list-group-item list-group-item-action">
+    <h5 class="mb-1">{{ collection.name }}</h5>
+    <p class="mb-1">{{ collection.description }}</p>
+  </a>
+  {% empty %}
+  <p>No collections available.</p>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/designs/templates/designs/design_detail.html
+++ b/designs/templates/designs/design_detail.html
@@ -1,0 +1,10 @@
+{% extends "designs/base.html" %}
+{% block title %}{{ design.name }}{% endblock %}
+{% block content %}
+<h1 class="mb-4">{{ design.name }}</h1>
+<p>{{ design.description }}</p>
+<p class="text-muted">Size: {{ design.dimensions.width }}x{{ design.dimensions.height }}</p>
+<p>
+  Collection: <a href="{% url 'collection-detail' design.collection.pk %}">{{ design.collection.name }}</a>
+</p>
+{% endblock %}

--- a/designs/test_views.py
+++ b/designs/test_views.py
@@ -1,0 +1,27 @@
+from test_plus.test import TestCase
+
+from designs.factories import CollectionFactory, DesignFactory
+
+
+class CollectionViewTests(TestCase):
+    def setUp(self):
+        self.collection = CollectionFactory()
+        self.design = DesignFactory(collection=self.collection)
+
+    def test_collection_list_view(self):
+        response = self.get("collection-list")
+        self.response_200(response)
+        self.assertContains(response, self.collection.name)
+
+    def test_collection_detail_view(self):
+        response = self.get("collection-detail", pk=self.collection.pk)
+        self.response_200(response)
+        self.assertContains(response, self.collection.name)
+        self.assertContains(response, self.design.name)
+
+    def test_design_detail_view(self):
+        response = self.get("design-detail", pk=self.design.pk)
+        self.response_200(response)
+        self.assertContains(response, self.design.name)
+        self.assertContains(response, self.collection.name)
+

--- a/designs/urls.py
+++ b/designs/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from designs import views
+
+urlpatterns = [
+    path("collections/", views.CollectionListView.as_view(), name="collection-list"),
+    path(
+        "collections/<uuid:pk>/",
+        views.CollectionDetailView.as_view(),
+        name="collection-detail",
+    ),
+    path("designs/<uuid:pk>/", views.DesignDetailView.as_view(), name="design-detail"),
+]

--- a/designs/views.py
+++ b/designs/views.py
@@ -1,1 +1,27 @@
-# Create your views here.
+from django.views.generic import DetailView, ListView
+
+from designs.models import Collection, Design
+
+
+class CollectionListView(ListView):
+    model = Collection
+    template_name = "designs/collection_list.html"
+    context_object_name = "collections"
+
+
+class CollectionDetailView(DetailView):
+    model = Collection
+    template_name = "designs/collection_detail.html"
+    context_object_name = "collection"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["designs"] = self.object.designs.all()
+        return context
+
+
+class DesignDetailView(DetailView):
+    model = Design
+    template_name = "designs/design_detail.html"
+    context_object_name = "design"
+

--- a/project/urls.py
+++ b/project/urls.py
@@ -16,8 +16,9 @@ Including another URLconf
 """
 
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("", include("designs.urls")),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,14 @@ dependencies = [
     "cattrs>=25.1.1",
     "django>=5.2.3",
     "django-markdownfield>=0.11.0",
+    "packaging>=23.2",
 ]
 
 [dependency-groups]
 dev = [
     "coverage>=7.9.1",
     "factory-boy>=3.3.3",
+    "django-test-plus>=2.2.4",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- add Bootstrap base template
- list and detail views for collections and designs
- wire up new URLs
- provide tests with django-test-plus
- include required dependencies

## Testing
- `uvx tox -q`

------
https://chatgpt.com/codex/tasks/task_e_685562caa1b883248d3ab7d9437a6914