### PR TITLE
Add bootstrap views for collections

### DIFF
--- a/designs/templates/designs/base.html
+++ b/designs/templates/designs/base.html
@@ -7,6 +7,11 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   </head>
   <body class="container py-4">
+    <nav aria-label="breadcrumb" class="mb-4">
+      <ol class="breadcrumb mb-0">
+        {% block breadcrumbs %}{% endblock %}
+      </ol>
+    </nav>
     {% block content %}{% endblock %}
   </body>
 </html>

--- a/designs/templates/designs/collection_detail.html
+++ b/designs/templates/designs/collection_detail.html
@@ -8,14 +8,21 @@
 <h1 class="mb-4">{{ collection.name }}</h1>
 <p class="mb-4">{{ collection.description }}</p>
 <h2 class="mb-3">Designs</h2>
-<div class="list-group">
+<div class="row row-cols-1 row-cols-md-2 row-cols-lg-4 g-3">
   {% for design in designs %}
-  <a href="{% url 'design-detail' collection_pk=collection.pk pk=design.pk %}" class="list-group-item list-group-item-action">
-    <svg class="img-fluid border mb-2" width="{{ design.dimensions.width }}" height="{{ design.dimensions.height }}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="{{ design.dimensions.width }}x{{ design.dimensions.height }}" preserveAspectRatio="none">
-      <rect width="100%" height="100%" fill="#e9ecef"></rect>
-    </svg>
-    {{ design.name }} ({{ design.dimensions.width }}x{{ design.dimensions.height }})
-  </a>
+  <div class="col">
+    <a href="{% url 'design-detail' collection_pk=collection.pk pk=design.pk %}" class="text-decoration-none text-body">
+      <div class="card h-100">
+        <svg class="card-img-top img-fluid border" width="{{ design.dimensions.width }}" height="{{ design.dimensions.height }}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="{{ design.dimensions.width }}x{{ design.dimensions.height }}" preserveAspectRatio="none">
+          <rect width="100%" height="100%" fill="#e9ecef"></rect>
+        </svg>
+        <div class="card-body">
+          <h5 class="card-title mb-1">{{ design.name }}</h5>
+          <p class="card-text text-muted">{{ design.dimensions.width }}x{{ design.dimensions.height }}</p>
+        </div>
+      </div>
+    </a>
+  </div>
   {% empty %}
   <p>No designs available.</p>
   {% endfor %}

--- a/designs/templates/designs/collection_detail.html
+++ b/designs/templates/designs/collection_detail.html
@@ -1,12 +1,19 @@
 {% extends "designs/base.html" %}
 {% block title %}{{ collection.name }}{% endblock %}
+{% block breadcrumbs %}
+<li class="breadcrumb-item"><a href="{% url 'collection-list' %}">Collections</a></li>
+<li class="breadcrumb-item active" aria-current="page">{{ collection.name }}</li>
+{% endblock %}
 {% block content %}
 <h1 class="mb-4">{{ collection.name }}</h1>
 <p class="mb-4">{{ collection.description }}</p>
 <h2 class="mb-3">Designs</h2>
 <div class="list-group">
   {% for design in designs %}
-  <a href="{% url 'design-detail' design.pk %}" class="list-group-item list-group-item-action">
+  <a href="{% url 'design-detail' collection_pk=collection.pk pk=design.pk %}" class="list-group-item list-group-item-action">
+    <svg class="img-fluid border mb-2" width="{{ design.dimensions.width }}" height="{{ design.dimensions.height }}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="{{ design.dimensions.width }}x{{ design.dimensions.height }}" preserveAspectRatio="none">
+      <rect width="100%" height="100%" fill="#e9ecef"></rect>
+    </svg>
     {{ design.name }} ({{ design.dimensions.width }}x{{ design.dimensions.height }})
   </a>
   {% empty %}

--- a/designs/templates/designs/collection_list.html
+++ b/designs/templates/designs/collection_list.html
@@ -1,5 +1,8 @@
 {% extends "designs/base.html" %}
 {% block title %}Collections{% endblock %}
+{% block breadcrumbs %}
+<li class="breadcrumb-item active" aria-current="page">Collections</li>
+{% endblock %}
 {% block content %}
 <h1 class="mb-4">Collections</h1>
 <div class="list-group">

--- a/designs/templates/designs/design_detail.html
+++ b/designs/templates/designs/design_detail.html
@@ -1,7 +1,15 @@
 {% extends "designs/base.html" %}
 {% block title %}{{ design.name }}{% endblock %}
+{% block breadcrumbs %}
+<li class="breadcrumb-item"><a href="{% url 'collection-list' %}">Collections</a></li>
+<li class="breadcrumb-item"><a href="{% url 'collection-detail' design.collection.pk %}">{{ design.collection.name }}</a></li>
+<li class="breadcrumb-item active" aria-current="page">{{ design.name }}</li>
+{% endblock %}
 {% block content %}
 <h1 class="mb-4">{{ design.name }}</h1>
+<svg class="img-fluid border mb-3" width="{{ design.dimensions.width }}" height="{{ design.dimensions.height }}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="{{ design.dimensions.width }}x{{ design.dimensions.height }}" preserveAspectRatio="none">
+  <rect width="100%" height="100%" fill="#e9ecef"></rect>
+</svg>
 <p>{{ design.description }}</p>
 <p class="text-muted">Size: {{ design.dimensions.width }}x{{ design.dimensions.height }}</p>
 <p>

--- a/designs/test_form_fields.py
+++ b/designs/test_form_fields.py
@@ -1,0 +1,23 @@
+from django.forms import modelform_factory
+from django.test import TestCase
+
+from designs.factories import CollectionFactory
+from designs.models import Design
+
+
+class DesignFormFieldTests(TestCase):
+    def test_invalid_dimensions_json(self):
+        collection = CollectionFactory()
+        Form = modelform_factory(Design, fields=["name", "collection", "dimensions"])
+        form = Form(
+            data={
+                "name": "Test Design",
+                "collection": collection.pk,
+                "dimensions": '{"width":999,"height":999}',
+            }
+        )
+        self.assertFormError(
+            form,
+            "dimensions",
+            "Select a valid choice. DesignSize(width=999, height=999) is not one of the available choices.",
+        )

--- a/designs/test_views.py
+++ b/designs/test_views.py
@@ -20,8 +20,9 @@ class CollectionViewTests(TestCase):
         self.assertContains(response, self.design.name)
 
     def test_design_detail_view(self):
-        response = self.get("design-detail", pk=self.design.pk)
+        response = self.get(
+            "design-detail", collection_pk=self.collection.pk, pk=self.design.pk
+        )
         self.response_200(response)
         self.assertContains(response, self.design.name)
         self.assertContains(response, self.collection.name)
-

--- a/designs/urls.py
+++ b/designs/urls.py
@@ -9,5 +9,9 @@ urlpatterns = [
         views.CollectionDetailView.as_view(),
         name="collection-detail",
     ),
-    path("designs/<uuid:pk>/", views.DesignDetailView.as_view(), name="design-detail"),
+    path(
+        "collections/<uuid:collection_pk>/designs/<uuid:pk>/",
+        views.DesignDetailView.as_view(),
+        name="design-detail",
+    ),
 ]

--- a/designs/views.py
+++ b/designs/views.py
@@ -25,3 +25,9 @@ class DesignDetailView(DetailView):
     template_name = "designs/design_detail.html"
     context_object_name = "design"
 
+    def get_queryset(self):
+        qs = super().get_queryset()
+        collection_pk = self.kwargs.get("collection_pk")
+        if collection_pk:
+            qs = qs.filter(collection__pk=collection_pk)
+        return qs


### PR DESCRIPTION
This pull request introduces several enhancements to the `designs` app, focusing on improving navigation, updating the UI for design collections, adding tests, and refining URL routing and view logic. The most significant changes include the addition of breadcrumb navigation, a card-based layout for collections, and updates to the `DesignDetailView` to filter designs by collection.

### Navigation Enhancements:
* Added a breadcrumb navigation block to improve user navigation across pages.
* Implemented breadcrumbs for each respective page to show hierarchical navigation paths.

### UI Improvements:
* Updated the layout to display designs in a responsive card-based grid instead of a list, improving visual appeal and usability.
* Added an SVG preview for design dimensions to provide a visual representation alongside design details.

### Routing and View Logic Updates:
* Modified the `design-detail` URL pattern to include the collection's UUID for better scoping and clarity.
* Updated `DesignDetailView` to filter designs by their associated collection, ensuring accurate data retrieval based on the new URL structure.

### Testing Additions:
* Added a test case to validate error handling for invalid dimensions JSON in design forms.
* Updated the `test_design_detail_view` to accommodate the new URL structure and verify the presence of collection details in the response.

------
https://chatgpt.com/codex/tasks/task_e_685562caa1b883248d3ab7d9437a6914