### PR TITLE
Render markdown fields as HTML

### DIFF
--- a/designs/templates/designs/collection_detail.html
+++ b/designs/templates/designs/collection_detail.html
@@ -1,4 +1,5 @@
 {% extends "designs/base.html" %}
+{% load markdown_extras %}
 {% block title %}{{ collection.name }}{% endblock %}
 {% block breadcrumbs %}
 <li class="breadcrumb-item"><a href="{% url 'collection-list' %}">Collections</a></li>
@@ -6,7 +7,7 @@
 {% endblock %}
 {% block content %}
 <h1 class="mb-4">{{ collection.name }}</h1>
-<p class="mb-4">{{ collection.description }}</p>
+<p class="mb-4">{{ collection.description|markdown_to_html }}</p>
 <h2 class="mb-3">Designs</h2>
 <div class="row row-cols-1 row-cols-md-2 row-cols-lg-4 g-3">
   {% for design in designs %}

--- a/designs/templates/designs/collection_list.html
+++ b/designs/templates/designs/collection_list.html
@@ -1,4 +1,5 @@
 {% extends "designs/base.html" %}
+{% load markdown_extras %}
 {% block title %}Collections{% endblock %}
 {% block breadcrumbs %}
 <li class="breadcrumb-item active" aria-current="page">Collections</li>
@@ -9,7 +10,7 @@
   {% for collection in collections %}
   <a href="{% url 'collection-detail' collection.pk %}" class="list-group-item list-group-item-action">
     <h5 class="mb-1">{{ collection.name }}</h5>
-    <p class="mb-1">{{ collection.description }}</p>
+    <p class="mb-1">{{ collection.description|markdown_to_html }}</p>
   </a>
   {% empty %}
   <p>No collections available.</p>

--- a/designs/templates/designs/design_detail.html
+++ b/designs/templates/designs/design_detail.html
@@ -1,4 +1,5 @@
 {% extends "designs/base.html" %}
+{% load markdown_extras %}
 {% block title %}{{ design.name }}{% endblock %}
 {% block breadcrumbs %}
 <li class="breadcrumb-item"><a href="{% url 'collection-list' %}">Collections</a></li>
@@ -10,7 +11,7 @@
 <svg class="img-fluid border mb-3" width="{{ design.dimensions.width }}" height="{{ design.dimensions.height }}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="{{ design.dimensions.width }}x{{ design.dimensions.height }}" preserveAspectRatio="none">
   <rect width="100%" height="100%" fill="#e9ecef"></rect>
 </svg>
-<p>{{ design.description }}</p>
+<p>{{ design.description|markdown_to_html }}</p>
 <p class="text-muted">Size: {{ design.dimensions.width }}x{{ design.dimensions.height }}</p>
 <p>
   Collection: <a href="{% url 'collection-detail' design.collection.pk %}">{{ design.collection.name }}</a>

--- a/designs/templatetags/markdown_extras.py
+++ b/designs/templatetags/markdown_extras.py
@@ -1,0 +1,42 @@
+from functools import partial
+
+import bleach
+from bleach.linkifier import LinkifyFilter
+from django import template
+from django.utils.safestring import mark_safe
+from markdown import markdown
+
+from markdownfield.models import EXTENSIONS, EXTENSION_CONFIGS
+from markdownfield.util import blacklist_link, format_link
+from markdownfield.validators import VALIDATOR_STANDARD
+
+register = template.Library()
+
+
+@register.filter(name="markdown_to_html")
+def markdown_to_html(value: str) -> str:
+    """Render markdown text as safe HTML."""
+    if not value:
+        return ""
+
+    dirty = markdown(text=value, extensions=EXTENSIONS, extension_configs=EXTENSION_CONFIGS)
+
+    if VALIDATOR_STANDARD.sanitize:
+        if VALIDATOR_STANDARD.linkify:
+            cleaner = bleach.Cleaner(
+                tags=VALIDATOR_STANDARD.allowed_tags,
+                attributes=VALIDATOR_STANDARD.allowed_attrs,
+                css_sanitizer=VALIDATOR_STANDARD.css_sanitizer,
+                filters=[partial(LinkifyFilter, callbacks=[format_link, blacklist_link])],
+            )
+        else:
+            cleaner = bleach.Cleaner(
+                tags=VALIDATOR_STANDARD.allowed_tags,
+                attributes=VALIDATOR_STANDARD.allowed_attrs,
+                css_sanitizer=VALIDATOR_STANDARD.css_sanitizer,
+            )
+        clean = cleaner.clean(dirty)
+    else:
+        clean = dirty
+
+    return mark_safe(clean)

--- a/designs/test_views.py
+++ b/designs/test_views.py
@@ -8,6 +8,14 @@ class CollectionViewTests(TestCase):
         self.collection = CollectionFactory()
         self.design = DesignFactory(collection=self.collection)
 
+    def test_markdown_rendered_as_html(self):
+        self.collection.description = "This **is** bold"
+        self.collection.save()
+
+        response = self.get("collection-detail", pk=self.collection.pk)
+        self.response_200(response)
+        self.assertContains(response, "<strong>is</strong>", html=True)
+
     def test_collection_list_view(self):
         response = self.get("collection-list")
         self.response_200(response)

--- a/uv.lock
+++ b/uv.lock
@@ -46,11 +46,13 @@ dependencies = [
     { name = "cattrs" },
     { name = "django" },
     { name = "django-markdownfield" },
+    { name = "packaging" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "django-test-plus" },
     { name = "factory-boy" },
 ]
 
@@ -60,11 +62,13 @@ requires-dist = [
     { name = "cattrs", specifier = ">=25.1.1" },
     { name = "django", specifier = ">=5.2.3" },
     { name = "django-markdownfield", specifier = ">=0.11.0" },
+    { name = "packaging", specifier = ">=23.2" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=7.9.1" },
+    { name = "django-test-plus", specifier = ">=2.2.4" },
     { name = "factory-boy", specifier = ">=3.3.3" },
 ]
 
@@ -165,6 +169,15 @@ wheels = [
 ]
 
 [[package]]
+name = "django-test-plus"
+version = "2.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/56/7d78cffc6d3b4240264d0ae34a86f6e2a1ce76e57ac40c2db437c80c5306/django-test-plus-2.2.4.tar.gz", hash = "sha256:06488209a07dca60dc2bbeaeae5ce340d17344163e0b121709cdac7405c6d9ef", size = 18869, upload-time = "2024-06-24T11:22:07.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/5c/d1720506e57eac09f37c0731a0183982b03a6b76be2fbd364d784e75ca73/django_test_plus-2.2.4-py3-none-any.whl", hash = "sha256:96e4e16fabd3e0339a4b46e02a0a88c92c19800de38d00446571ea036614d332", size = 17485, upload-time = "2024-06-24T11:22:05.669Z" },
+]
+
+[[package]]
 name = "factory-boy"
 version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -195,6 +208,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2f/15/222b423b0b88689c266d9eac4e61396fe2cc53464459d6a37618ac863b24/markdown-3.8.tar.gz", hash = "sha256:7df81e63f0df5c4b24b7d156eb81e4690595239b7d70937d0409f1b0de319c6f", size = 360906, upload-time = "2025-04-11T14:42:50.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/3f/afe76f8e2246ffbc867440cbcf90525264df0e658f8a5ca1f872b3f6192a/markdown-3.8-py3-none-any.whl", hash = "sha256:794a929b79c5af141ef5ab0f2f642d0f7b1872981250230e72682346f7cc90dc", size = 106210, upload-time = "2025-04-11T14:42:49.178Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- render markdown fields as HTML in templates
- add `markdown_to_html` Django template filter for sanitised rendering
- test that markdown content renders as HTML

## Testing
- `python manage.py test -v2`

------
https://chatgpt.com/codex/tasks/task_e_6856b8b88a0083249360a32ceecba98a