### PR TITLE
Implement font filtering with Django forms

### DIFF
--- a/designs/forms.py
+++ b/designs/forms.py
@@ -1,0 +1,27 @@
+from django import forms
+
+
+class FontFilterForm(forms.Form):
+    """Validate filter parameters for FontListView."""
+
+    lang = forms.CharField(required=False, label="Language")
+    family = forms.CharField(required=False, label="Family")
+    style = forms.CharField(required=False, label="Style")
+
+    GROUP_CHOICES = [
+        ("", "No grouping"),
+        ("lang", "Language"),
+        ("family", "Family"),
+        ("style", "Style"),
+    ]
+    group_by = forms.ChoiceField(required=False, choices=GROUP_CHOICES, label="Group by")
+
+    def get_filters(self) -> dict:
+        """Return cleaned filter values suitable for fontconfig.query."""
+        if not self.is_valid():
+            return {}
+        return {
+            key: value
+            for key, value in self.cleaned_data.items()
+            if key in {"lang", "family", "style"} and value
+        }

--- a/designs/templates/designs/font_list.html
+++ b/designs/templates/designs/font_list.html
@@ -9,29 +9,44 @@
 
 {% block content %}
 <h1 class="mb-4">Fonts</h1>
-<div class="list-group">
+
+<form method="get" class="row gy-2 mb-4">
+    <div class="col-md-auto">{{ form.lang.label_tag }} {{ form.lang }}</div>
+    <div class="col-md-auto">{{ form.family.label_tag }} {{ form.family }}</div>
+    <div class="col-md-auto">{{ form.style.label_tag }} {{ form.style }}</div>
+    <div class="col-md-auto">{{ form.group_by.label_tag }} {{ form.group_by }}</div>
+    <div class="col-md-auto align-self-end">
+        <button type="submit" class="btn btn-primary">Apply</button>
+        <a href="{% url 'font-list' %}" class="btn btn-secondary">Reset</a>
+    </div>
+</form>
 
 {% if grouped_fonts %}
     {% for group, fonts in grouped_fonts.items %}
         <h4 class="mt-3 mb-2">{{ group }}</h4>
+        <div class="list-group mb-3">
         {% for font in fonts|dictsort:"family.en" %}
-        <a href="#" class="list-group-item list-group-item-action">
-            <h5 class="mb-1" style="font-family: '{{ font.family.en }}';">{{ font }}</h5>
-        </a>
+            <div class="list-group-item">
+                <span style="font-family: '{{ font.family.en }}';">{{ font }}</span>
+            </div>
+        {% empty %}
+            <p>No fonts available.</p>
         {% endfor %}
+        </div>
     {% empty %}
         <p>No fonts available.</p>
     {% endfor %}
 {% elif fonts %}
+    <div class="list-group">
     {% for font in fonts|dictsort:"family.en" %}
-        <a href="{% querystring family=font.family.en %}" class="list-group-item list-group-item-action">
-            <h5 class="mb-1" style="font-family: '{{ font.family.en }}';">{{ font }}</h5>
-        </a>
+        <div class="list-group-item">
+            <span style="font-family: '{{ font.family.en }}';">{{ font }}</span>
+        </div>
     {% empty %}
         <p>No fonts available.</p>
     {% endfor %}
+    </div>
 {% else %}
-    <p>Unexpected error</p>
+    <p>No fonts available.</p>
 {% endif %}
-</div>
 {% endblock %}

--- a/designs/test_font_views.py
+++ b/designs/test_font_views.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from test_plus.test import TestCase
+
+
+class FontListViewTests(TestCase):
+    url_name = "font-list"
+
+    def setUp(self):
+        self.font1 = SimpleNamespace(family={"en": "A"}, style={"en": "Regular"}, lang="en")
+        self.font2 = SimpleNamespace(family={"en": "B"}, style={"en": "Bold"}, lang="en")
+
+    @patch("designs.views.fontconfig.FcFont")
+    @patch("designs.views.fontconfig.query")
+    def test_filters_and_grouping(self, mock_query, mock_fcfont):
+        mock_query.return_value = ["f1", "f2"]
+        mock_fcfont.side_effect = [self.font1, self.font2]
+        response = self.get(self.url_name, data={"lang": "en", "group_by": "family"})
+        self.response_200(response)
+        mock_query.assert_called_with(lang="en")
+        self.assertIn("grouped_fonts", response.context)
+        self.assertIn("A", response.context["grouped_fonts"]) 
+        self.assertTrue(response.context["form"].is_valid())
+
+    @patch("designs.views.fontconfig.FcFont")
+    @patch("designs.views.fontconfig.query")
+    def test_no_grouping(self, mock_query, mock_fcfont):
+        mock_query.return_value = ["f1"]
+        mock_fcfont.return_value = self.font1
+        response = self.get(self.url_name, data={"family": "A"})
+        self.response_200(response)
+        mock_query.assert_called_with(family="A")
+        self.assertIn("fonts", response.context)
+        self.assertTrue(response.context["form"].is_valid())
+


### PR DESCRIPTION
## Summary
- add a `FontFilterForm` for validating user input
- update `FontListView` to filter and group fonts using the form
- redesign `font_list.html` with a filter form
- test font filtering and grouping logic

## Testing
- `python manage.py test -v2`

------
https://chatgpt.com/codex/tasks/task_e_685c77da34ac83249273088eef585769